### PR TITLE
Add post_post method to WPApiHandler

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ npm install wpapihandler
 ```
 
 # Documentation
-For more detailed documentation, please refer to [the official documentation](./docs/modules.md).
+For more detailed documentation, please refer to [the official documentation](./modules.md).
 
 # Changelog
 See the [CHANGELOG.md](./CHANGELOG.md) for current version changes.

--- a/docs/classes/errors_errors.HeaderError.md
+++ b/docs/classes/errors_errors.HeaderError.md
@@ -50,7 +50,7 @@ Error.constructor
 
 #### Defined in
 
-[errors/errors.ts:9](https://github.com/MichaelGloessl04/wpapihandler/blob/e0b843b/errors/errors.ts#L9)
+[errors/errors.ts:9](https://github.com/MichaelGloessl04/wpapihandler/blob/51f079e/errors/errors.ts#L9)
 
 ## Properties
 

--- a/docs/classes/errors_errors.InvalidURLError.md
+++ b/docs/classes/errors_errors.InvalidURLError.md
@@ -50,7 +50,7 @@ Error.constructor
 
 #### Defined in
 
-[errors/errors.ts:2](https://github.com/MichaelGloessl04/wpapihandler/blob/e0b843b/errors/errors.ts#L2)
+[errors/errors.ts:2](https://github.com/MichaelGloessl04/wpapihandler/blob/51f079e/errors/errors.ts#L2)
 
 ## Properties
 

--- a/docs/classes/index.WPApiHandler.md
+++ b/docs/classes/index.WPApiHandler.md
@@ -23,6 +23,7 @@
 - [get\_events](index.WPApiHandler.md#get_events)
 - [get\_posts](index.WPApiHandler.md#get_posts)
 - [post\_len](index.WPApiHandler.md#post_len)
+- [post\_post](index.WPApiHandler.md#post_post)
 
 ## Constructors
 
@@ -57,7 +58,7 @@ const wpa = new WPApiHandler(
 
 #### Defined in
 
-[index.ts:40](https://github.com/MichaelGloessl04/wpapihandler/blob/e0b843b/index.ts#L40)
+[index.ts:46](https://github.com/MichaelGloessl04/wpapihandler/blob/51f079e/index.ts#L46)
 
 ## Properties
 
@@ -67,7 +68,7 @@ const wpa = new WPApiHandler(
 
 #### Defined in
 
-[index.ts:22](https://github.com/MichaelGloessl04/wpapihandler/blob/e0b843b/index.ts#L22)
+[index.ts:28](https://github.com/MichaelGloessl04/wpapihandler/blob/51f079e/index.ts#L28)
 
 ___
 
@@ -77,7 +78,7 @@ ___
 
 #### Defined in
 
-[index.ts:21](https://github.com/MichaelGloessl04/wpapihandler/blob/e0b843b/index.ts#L21)
+[index.ts:27](https://github.com/MichaelGloessl04/wpapihandler/blob/51f079e/index.ts#L27)
 
 ## Methods
 
@@ -132,7 +133,7 @@ try {
 
 #### Defined in
 
-[index.ts:171](https://github.com/MichaelGloessl04/wpapihandler/blob/e0b843b/index.ts#L171)
+[index.ts:220](https://github.com/MichaelGloessl04/wpapihandler/blob/51f079e/index.ts#L220)
 
 ___
 
@@ -152,7 +153,7 @@ ___
 
 #### Defined in
 
-[index.ts:230](https://github.com/MichaelGloessl04/wpapihandler/blob/e0b843b/index.ts#L230)
+[index.ts:277](https://github.com/MichaelGloessl04/wpapihandler/blob/51f079e/index.ts#L277)
 
 ___
 
@@ -172,7 +173,7 @@ ___
 
 #### Defined in
 
-[index.ts:201](https://github.com/MichaelGloessl04/wpapihandler/blob/e0b843b/index.ts#L201)
+[index.ts:248](https://github.com/MichaelGloessl04/wpapihandler/blob/51f079e/index.ts#L248)
 
 ___
 
@@ -196,7 +197,7 @@ The method should not be used
 
 #### Defined in
 
-[index.ts:80](https://github.com/MichaelGloessl04/wpapihandler/blob/e0b843b/index.ts#L80)
+[index.ts:86](https://github.com/MichaelGloessl04/wpapihandler/blob/51f079e/index.ts#L86)
 
 ___
 
@@ -251,7 +252,7 @@ console.error(errorPost.status, specificPost.error);
 
 #### Defined in
 
-[index.ts:120](https://github.com/MichaelGloessl04/wpapihandler/blob/e0b843b/index.ts#L120)
+[index.ts:126](https://github.com/MichaelGloessl04/wpapihandler/blob/51f079e/index.ts#L126)
 
 ___
 
@@ -286,4 +287,53 @@ const totalPosts = await wpa.post_len();
 
 #### Defined in
 
-[index.ts:64](https://github.com/MichaelGloessl04/wpapihandler/blob/e0b843b/index.ts#L64)
+[index.ts:70](https://github.com/MichaelGloessl04/wpapihandler/blob/51f079e/index.ts#L70)
+
+___
+
+### post\_post
+
+▸ **post_post**(`new_post?`): `Promise`\<[`ServerData`](../modules/index.md#serverdata)\>
+
+Asynchronously posts a new post to the WordPress site.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `new_post?` | [`Post`](../modules/index.md#post) | The post to be posted to the WordPress site. |
+
+#### Returns
+
+`Promise`\<[`ServerData`](../modules/index.md#serverdata)\>
+
+A promise that resolves to an object containing the status and data/error of the request.
+
+**`Throws`**
+
+Error if an unexpected error occurs during the execution of the method.
+
+**`Example`**
+
+```ts
+const wpa = new WPApiHandler(
+     'https://example.com',
+     {
+         "Content-Type": "application/json",
+         "Authorization": "Basic YOURACCESSTOKEN"
+     }
+);
+
+const new_post = {
+     title: 'New Post',
+     content: 'This is a new post.',
+     status: 'publish',
+};
+
+const result = await wpa.post_post(new_post);
+console.log(result.status, result.data);
+```
+
+#### Defined in
+
+[index.ts:172](https://github.com/MichaelGloessl04/wpapihandler/blob/51f079e/index.ts#L172)

--- a/docs/interfaces/index.Headers.md
+++ b/docs/interfaces/index.Headers.md
@@ -23,7 +23,7 @@
 
 #### Defined in
 
-[index.ts:16](https://github.com/MichaelGloessl04/wpapihandler/blob/e0b843b/index.ts#L16)
+[index.ts:22](https://github.com/MichaelGloessl04/wpapihandler/blob/51f079e/index.ts#L22)
 
 ___
 
@@ -33,4 +33,4 @@ ___
 
 #### Defined in
 
-[index.ts:15](https://github.com/MichaelGloessl04/wpapihandler/blob/e0b843b/index.ts#L15)
+[index.ts:21](https://github.com/MichaelGloessl04/wpapihandler/blob/51f079e/index.ts#L21)

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -14,9 +14,28 @@
 
 ### Type Aliases
 
+- [Post](index.md#post)
 - [ServerData](index.md#serverdata)
 
 ## Type Aliases
+
+### Post
+
+Ƭ **Post**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `content` | `string` |
+| `status` | `string` |
+| `title` | `string` |
+
+#### Defined in
+
+[index.ts:14](https://github.com/MichaelGloessl04/wpapihandler/blob/51f079e/index.ts#L14)
+
+___
 
 ### ServerData
 
@@ -24,4 +43,4 @@
 
 #### Defined in
 
-[index.ts:4](https://github.com/MichaelGloessl04/wpapihandler/blob/e0b843b/index.ts#L4)
+[index.ts:4](https://github.com/MichaelGloessl04/wpapihandler/blob/51f079e/index.ts#L4)

--- a/index.ts
+++ b/index.ts
@@ -11,6 +11,13 @@ export type ServerData =
           error: Error;
       };
 
+export type Post = {
+    title: string;
+    content: string;
+    status: string;
+    [key: string]: any;
+};
+
 export interface Headers {
     'Content-Type': string;
     Authorization: string;
@@ -126,7 +133,7 @@ export class WPApiHandler {
             if (response[0] == 200) {
                 return {
                     status: 200,
-                    data: [response[2]],
+                    data: response[2],
                 };
             } else {
                 return {
@@ -136,6 +143,49 @@ export class WPApiHandler {
             }
         } else {
             return await this.get_amount(total);
+        }
+    }
+
+    /**
+     * Asynchronously posts a new post to the WordPress site.
+     *
+     * @param {Post} [new_post]: The post to be posted to the WordPress site.
+     * @returns {Promise<ServerData>} A promise that resolves to an object containing the status and data/error of the request.
+     * @throws {@link Error} if an unexpected error occurs during the execution of the method.
+     * @example
+     * const wpa = new WPApiHandler(
+     *      'https://example.com',
+     *      {
+     *          "Content-Type": "application/json",
+     *          "Authorization": "Basic YOURACCESSTOKEN"
+     *      }
+     * );
+     * 
+     * const new_post = {
+     *      title: 'New Post',
+     *      content: 'This is a new post.',
+     *      status: 'publish',
+     * };
+     * 
+     * const result = await wpa.post_post(new_post);
+     * console.log(result.status, result.data);
+     */
+    async post_post(new_post: Post): Promise<ServerData> {
+        try {
+            const response = await axios.post(
+                `${this.server_address}/wp-json/wp/v2/posts/`,
+                new_post,
+                this.headers,
+            );
+            return {
+                status: 200,
+                data: response.data,
+            };
+        } catch (error: any) {
+            return {
+                status: error.response.status,
+                error: Error(error.response.statusText),
+            };
         }
     }
 
@@ -176,10 +226,8 @@ export class WPApiHandler {
             );
 
             if (response.status === 200) {
-                console.log('Connection successful!');
                 return true;
             } else {
-                console.error(`Unexpected response status: ${response.status}`);
                 return false;
             }
         } catch (error) {

--- a/tests/test-runner.ts
+++ b/tests/test-runner.ts
@@ -5,6 +5,7 @@ import {
     test_wpa_check_connection,
     test_wpa_post_len,
     test_wpa_get_all_posts,
+    test_wpa_post_post,
 } from "./test_wpapihandler";
 import { AssertionError } from "assert";
 
@@ -14,6 +15,7 @@ const tests: (() => boolean | Promise<boolean>)[] = [
     test_wpa_check_connection,
     test_wpa_post_len,
     test_wpa_get_all_posts,
+    test_wpa_post_post,
 ];
 
 async function executeTest(test: () => boolean | Promise<boolean>) {

--- a/tests/test_wpapihandler.ts
+++ b/tests/test_wpapihandler.ts
@@ -85,3 +85,28 @@ export async function test_wpa_get_all_posts(): Promise<boolean> {
 
     return true;
 }
+
+
+export async function test_wpa_post_post(): Promise<boolean> {
+    const config = get_config();
+    const wpa = new WPApiHandler(config.correct.URL, config.correct.headers);
+    const new_post = {
+        title: "Test post",
+        content: "This is a test post.",
+        status: "publish",
+    };
+
+    const response: any = await wpa.post_post(new_post);
+    if (response.status !== 200) {
+        console.error("Error posting data:", response.error);
+        return false;
+    }else if (typeof response.data !== 'object' || !response.data.hasOwnProperty('id')) {
+        console.error("Invalid post object:", typeof response.data);
+        return false;
+    }else if (response.data.title.rendered !== new_post.title) {
+        console.error(`Post title is ${response.data.title.rendered}, expected ${new_post.title}.`);
+        return false;
+    }
+
+    return true;
+}


### PR DESCRIPTION
This pull request adds a new method called post_post to the WPApiHandler class. The method allows users to asynchronously post a new post to a WordPress site. The method takes a Post object as a parameter and returns a promise that resolves to an object containing the status and data/error of the request.